### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.Linq.Conditions/Pure.Linq.Conditions.csproj
+++ b/src/Pure.Linq.Conditions/Pure.Linq.Conditions.csproj
@@ -4,6 +4,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.1.0-preview.0.2.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Linq.Conditions</PackageId>


### PR DESCRIPTION
Closes #38

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.